### PR TITLE
docs: add support policy and quality checks

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Create interactive SVG maps in React with d3-geo and topojson using a TypeScript
 
 > Modernized fork of [react-simple-maps](https://github.com/zcreativelabs/react-simple-maps) with React 19 support and TypeScript-first tooling.
 
+## Why this package?
+
+- Built specifically for **React 19+** instead of preserving compatibility with older React release lines.
+- Ships as a **modern ESM-only library** with explicit exports, tree-shakeable output, and TypeScript definitions.
+- Provides a **TypeScript-first API** with branded coordinate helpers that reduce common map-coordinate mistakes.
+- Includes **safer URL-based geography loading** with validation, HTTPS-first defaults, response-size checks, and optional SRI helpers.
+
 ## Key Features
 
 - React 19+ only (peer dependencies)
@@ -25,6 +32,8 @@ Create interactive SVG maps in React with d3-geo and topojson using a TypeScript
 
 - [npm Package](https://www.npmjs.com/package/@vnedyalk0v/react19-simple-maps)
 - [Examples](./examples/)
+- [Support Policy](./docs/support.md)
+- [CI/CD Architecture](./docs/ci-cd.md)
 - [Changelog](./CHANGELOG.md)
 - [Issues](https://github.com/vnedyalk0v/react19-simple-maps/issues)
 - [Discussions](https://github.com/vnedyalk0v/react19-simple-maps/discussions)
@@ -52,6 +61,8 @@ pnpm add @vnedyalk0v/react19-simple-maps
 - **React DOM**: 19.0.0 or higher (peer dependency)
 - **Node.js**: 20.19.0 or higher (development/build)
 - **TypeScript**: 5.0.0 or higher (recommended)
+
+For support expectations, compatibility boundaries, and release behavior, see the [Support Policy](./docs/support.md).
 
 ## Utilities Subpath
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,29 @@
+# Support Policy
+
+## Runtime and package support
+
+- `@vnedyalk0v/react19-simple-maps` supports **React 19 or newer**.
+- The published package is **ESM-only**. Use `import` syntax rather than `require(...)`.
+- The package targets modern bundler-based application setups that understand the package `exports` field.
+
+## Development and build support
+
+- Local development, tests, and package builds require **Node.js 20.19.0 or newer**.
+- CI validates the repository on **Node.js 20** and **Node.js 22**.
+
+## API and release expectations
+
+- The package follows semantic versioning for its documented public API.
+- Additive, non-breaking improvements should ship in patch or minor releases.
+- Breaking API, packaging, or supported-platform changes should ship only in a major release unless explicitly documented otherwise.
+
+## Security and data fetching expectations
+
+- URL-based geography loading keeps HTTPS-only defaults in production.
+- Geography validation and fetch hardening are part of the supported package behavior, not example-only helpers.
+- Security-sensitive changes should ship with matching tests and documentation updates.
+
+## Examples and documentation
+
+- The examples are maintained as supported usage references for the current package version.
+- Documentation aims to reflect the current implementation and supported call order for configuration APIs.

--- a/scripts/enhanced-bundle-monitor.js
+++ b/scripts/enhanced-bundle-monitor.js
@@ -199,6 +199,13 @@ function analyzeOptimizations(content, filePath = '') {
   return analysis;
 }
 
+function execGitCommand(command) {
+  return execSync(command, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+}
+
 function generateEnhancedReport() {
   const bundlePaths = Object.keys(BUNDLE_TARGETS);
   const analyses = bundlePaths.map(analyzeBundle);
@@ -214,7 +221,7 @@ function generateEnhancedReport() {
   if (!redactGit) {
     try {
       gitInfo = {
-        commit: execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim(),
+        commit: execGitCommand('git rev-parse HEAD'),
         branch: '<redacted>',
         timestamp: new Date().toISOString(),
       };

--- a/tests/bundle-monitor.test.ts
+++ b/tests/bundle-monitor.test.ts
@@ -216,6 +216,9 @@ describe('Bundle monitor: git metadata redaction', () => {
     delete process.env.BUNDLE_REPORT_REDACT_GIT;
 
     const savedPath = process.env.PATH;
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
     process.env.PATH = '';
     vi.resetModules();
 
@@ -230,7 +233,9 @@ describe('Bundle monitor: git metadata redaction', () => {
       } else {
         expect.fail('expected report.git to contain error string');
       }
+      expect(stderrSpy).not.toHaveBeenCalled();
     } finally {
+      stderrSpy.mockRestore();
       process.env.PATH = savedPath;
     }
   });


### PR DESCRIPTION
## Summary
Adds a short support policy, sharpens the README value proposition, suppresses noisy git-metadata test output from the bundle monitor path, and adds a dependency review workflow for PRs.

## What changed
- adds `docs/support.md` with support and compatibility expectations
- adds a concise "Why this package?" section and support links in the README
- suppresses shell noise when git metadata is unavailable in the bundle monitor path
- adds regression coverage so missing git metadata no longer writes noisy stderr output during tests
- adds a dependency review workflow for PRs to `dev` and `main`

## Validation
Passed:
- `npm run check-format`
- `npm test`
- `npm run ci`
