### PR TITLE
ci: publish after merged release PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
   workflow_dispatch:
 
 concurrency:
@@ -12,6 +17,15 @@ concurrency:
 
 jobs:
   release:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: release package')) ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.merged == true &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.head.ref == 'changeset-release/main'
+      )
     name: Release & Publish
     runs-on: ubuntu-latest
     permissions:
@@ -25,6 +39,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -52,6 +52,7 @@ Workflow: `.github/workflows/publish.yml`
 Runs on:
 
 - pushes to `main`
+- merged Changesets release PRs targeting `main`
 - manual dispatch
 
 Uses Changesets to:
@@ -65,7 +66,7 @@ Because the Changesets release PR is bot-created and can skip normal PR-triggere
 - validates its merge ref
 - reports the required `ci` check directly to the release branch head commit
 
-This keeps release PRs compatible with branch protection.
+This keeps release PRs compatible with branch protection. The same workflow also listens for merged release PRs so the publish step still runs even when the merge commit is authored by automation and does not trigger a follow-up `push` workflow reliably.
 
 ## Sync workflow
 


### PR DESCRIPTION
## Summary
- ensure the release workflow still publishes after a merged Changesets release PR even when the merge commit is bot-authored
- keep the existing push-to-main behavior for opening release PRs
- document the distinction in the CI/CD docs

## Why
The `Release & Publish` workflow correctly opened the Changesets release PR, but the follow-up publish did not trigger automatically after merging that PR because the resulting bot-authored commit did not fire the expected `push` workflow run.

## What changed
- add a `pull_request_target` trigger for merged release PRs targeting `main`
- run the publish workflow for merged `changeset-release/main` PRs
- skip the redundant push-path execution for `chore: release package` commits to avoid duplicate publish attempts
- update `docs/ci-cd.md` to document the release workflow behavior
