### PR TITLE
Fix synthesized geography key collisions

### DIFF
--- a/.changeset/unique-geography-fallback-keys.md
+++ b/.changeset/unique-geography-fallback-keys.md
@@ -1,0 +1,7 @@
+---
+'@vnedyalk0v/react19-simple-maps': patch
+---
+
+Synthesized prepared geography keys now avoid collisions with existing feature keys.
+
+- Fallback `rsmKey` values keep React list keys unique when a GeoJSON `id` or existing `rsmKey` already uses the same `geo-*` shape.

--- a/src/utils/geography-processing.ts
+++ b/src/utils/geography-processing.ts
@@ -195,7 +195,7 @@ export function prepareMesh(
   return result;
 }
 
-function getFeatureRsmKey(feature: Feature<Geometry>, index: number): string {
+function getExplicitFeatureKey(feature: Feature<Geometry>): string | null {
   const existingKey = (
     feature as Feature<Geometry> & { rsmKey?: string | number }
   ).rsmKey;
@@ -208,7 +208,26 @@ function getFeatureRsmKey(feature: Feature<Geometry>, index: number): string {
     return String(feature.id);
   }
 
-  return `geo-${index}`;
+  return null;
+}
+
+function getUniqueFallbackRsmKey(
+  index: number,
+  unavailableKeys: Set<string>,
+): string {
+  const baseKey = `geo-${index}`;
+  if (!unavailableKeys.has(baseKey)) {
+    return baseKey;
+  }
+
+  let suffix = 1;
+  let fallbackKey = `${baseKey}-${suffix}`;
+  while (unavailableKeys.has(fallbackKey)) {
+    suffix += 1;
+    fallbackKey = `${baseKey}-${suffix}`;
+  }
+
+  return fallbackKey;
 }
 
 /**
@@ -225,7 +244,7 @@ export function prepareFeatures(
     return [];
   }
 
-  return features
+  const preparedCandidates = features
     .map((feature, index) => {
       const svgPath = path(feature);
       if (!svgPath) {
@@ -233,12 +252,31 @@ export function prepareFeatures(
       }
 
       return {
-        ...feature,
+        explicitKey: getExplicitFeatureKey(feature),
+        feature,
+        index,
         svgPath,
-        rsmKey: getFeatureRsmKey(feature, index),
-      } as PreparedFeature;
+      };
     })
-    .filter((feature): feature is PreparedFeature => feature !== null);
+    .filter((feature) => feature !== null);
+
+  const unavailableKeys = new Set(
+    preparedCandidates
+      .map((candidate) => candidate.explicitKey)
+      .filter((rsmKey): rsmKey is string => rsmKey !== null),
+  );
+
+  return preparedCandidates.map(({ explicitKey, feature, index, svgPath }) => {
+    const rsmKey =
+      explicitKey ?? getUniqueFallbackRsmKey(index, unavailableKeys);
+    unavailableKeys.add(rsmKey);
+
+    return {
+      ...feature,
+      svgPath,
+      rsmKey,
+    } as PreparedFeature;
+  });
 }
 
 /**

--- a/tests/geographies-integration.test.tsx
+++ b/tests/geographies-integration.test.tsx
@@ -81,6 +81,27 @@ describe('Geographies integration', () => {
     ]);
   });
 
+  it('disambiguates fallback keys from existing feature keys', () => {
+    const keyedFeatures = [
+      {
+        ...featureCollection.features[0],
+        rsmKey: 'geo-1',
+      },
+      featureCollection.features[0],
+      {
+        ...featureCollection.features[0],
+        id: 'geo-2',
+      },
+      featureCollection.features[0],
+    ];
+
+    const prepared = prepareFeatures(keyedFeatures, geoPath());
+    const rsmKeys = prepared.map((geo) => geo.rsmKey);
+
+    expect(rsmKeys).toEqual(['geo-1', 'geo-1-1', 'geo-2', 'geo-3']);
+    expect(new Set(rsmKeys).size).toBe(rsmKeys.length);
+  });
+
   it('recomputes prepared SVG paths when the projection changes', async () => {
     const { container, rerender } = render(
       <ComposableMap projection="geoEqualEarth">


### PR DESCRIPTION
## Summary

- Reserve explicit prepared geography keys from existing `rsmKey` and GeoJSON `id` values before assigning synthesized fallbacks.
- Disambiguate synthesized `geo-${index}` fallback keys when they would collide with reserved or already assigned keys.
- Add regression coverage and a patch changeset for the collision case.

## Root cause

The `geo-${index}` fallback was deterministic but did not check whether an earlier explicit `rsmKey` or `id` already used the same value, which could produce duplicate React keys for `key={geo.rsmKey}` usage.

## Validation

- `npm test -- tests/geographies-integration.test.tsx` (red before implementation, green after)
- `npm run ci`
- `npm pack --dry-run --json --ignore-scripts`
- `git diff --check`