### PR TITLE
chore: promote dev to main

### DIFF
--- a/.changeset/stable-geography-keys.md
+++ b/.changeset/stable-geography-keys.md
@@ -1,0 +1,7 @@
+---
+'@vnedyalk0v/react19-simple-maps': patch
+---
+
+Prepared geographies now always expose a stable `rsmKey` value for React list keys.
+
+- Existing `rsmKey` values are preserved, feature `id` values are used when available, and deterministic index keys are used as a fallback.

--- a/.changeset/unique-geography-fallback-keys.md
+++ b/.changeset/unique-geography-fallback-keys.md
@@ -5,3 +5,4 @@
 Synthesized prepared geography keys now avoid collisions with existing feature keys.
 
 - Fallback `rsmKey` values keep React list keys unique when a GeoJSON `id` or existing `rsmKey` already uses the same `geo-*` shape.
+- Duplicate explicit `rsmKey` and GeoJSON `id` values are also disambiguated with stable suffixes.

--- a/.changeset/unique-geography-fallback-keys.md
+++ b/.changeset/unique-geography-fallback-keys.md
@@ -1,0 +1,7 @@
+---
+'@vnedyalk0v/react19-simple-maps': patch
+---
+
+Synthesized prepared geography keys now avoid collisions with existing feature keys.
+
+- Fallback `rsmKey` values keep React list keys unique when a GeoJSON `id` or existing `rsmKey` already uses the same `geo-*` shape.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run CI validation
         run: npm run ci
@@ -57,18 +57,21 @@ jobs:
             examples/interactive-map/package-lock.json
 
       - name: Install root dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Build root package
+        run: npm run build
 
       - name: Build basic example
         working-directory: examples/basic-map
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run build
 
       - name: Build interactive example
         working-directory: examples/interactive-map
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run build
 
   ci:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Create Release Pull Request or Publish
         id: changesets
@@ -118,7 +118,7 @@ jobs:
         id: release_pr_validation
         continue-on-error: true
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run ci
 
       - name: Complete release PR CI check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,9 @@ These rules apply when editing library code in `src/` and docs/examples in `exam
 ## Release Notes (Required)
 
 - For every user-facing or package-impacting change, create a new `.changeset/*.md` file that follows `RELEASE_NOTES_GUIDELINES.md`.
-- The changeset file must describe the change clearly so the changelog can be generated correctly.
-- For every user-facing or package-impacting change, update `CHANGELOG.md` in the standardized format described in `RELEASE_NOTES_GUIDELINES.md`.
-- Read `RELEASE_NOTES_GUIDELINES.md` only when the task requires a changeset or changelog update.
+- The changeset file must describe the change clearly so Changesets can generate changelog entries and release text.
+- Do not manually update `CHANGELOG.md` for normal feature or fix work; Changesets release PRs own generated version sections.
+- Read `RELEASE_NOTES_GUIDELINES.md` only when the task requires a changeset or explicit changelog maintenance.
 - Do not update `CHANGELOG.md` for tooling-only, CI-only, lockfile-only, or other internal-only maintenance.
 - Never reference internal tooling, review bots, or IDE names (e.g., CodeRabbit, Cursor, Copilot) in changesets, changelog entries, commit messages, code comments, or any user-facing text. Describe _what_ changed and _why_, not which tool suggested it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
+All notable changes to `@vnedyalk0v/react19-simple-maps` are documented in this file.
+
+This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
+the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## 2.0.8
+
+### Patch Changes
+
+- Updated development tooling and release workflow maintenance without changing the public runtime API.
+
+## 2.0.7
 
 ### Patch Changes
 
@@ -10,21 +21,6 @@
   - Applies the hardened geography URL validation pipeline to `generateSRIHash`.
   - Adds safer default geography error messaging.
   - Fails more predictably on malformed nested geography input.
-
-## 2.0.7
-
-### Changed
-
-- Hardened geography validation and cache isolation.
-  - Blocks prototype-mutation payloads during object validation and avoids inherited-value reads in projection and security config parsing.
-  - Replaces collision-prone geography cache keys with object-identity-based keys so different datasets or parsing functions do not reuse the wrong cached results.
-  - Applies the hardened geography URL validation pipeline to `generateSRIHash`.
-  - Adds safer default geography error messaging.
-  - Fails more predictably on malformed nested geography input.
-
-## [Unreleased]
-
-No unreleased user-facing or package-impacting changes.
 
 ## [2.0.6] - 2026-04-06
 
@@ -70,11 +66,6 @@ No unreleased user-facing or package-impacting changes.
 
 - Removed the built-in `ZoomableGroup` zoom and pan indicator.
   - Stops showing the built-in top-left zoom and pan indicator during map interactions so direct manipulation stays visually clean.
-
-All notable changes to `@vnedyalk0v/react19-simple-maps` are documented in this file.
-
-This changelog follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
-the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.0.3] - 2026-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Patch Changes
 
-- Updated development tooling and release workflow maintenance without changing the public runtime API.
+- Hardened geography validation and cache isolation.
+  - Blocks prototype-mutation payloads during object validation and avoids inherited-value reads in projection and security config parsing.
+  - Replaces collision-prone geography cache keys with object-identity-based keys so different datasets or parsing functions do not reuse the wrong cached results.
+  - Applies the hardened geography URL validation pipeline to `generateSRIHash`.
+  - Adds safer default geography error messaging.
+  - Fails more predictably on malformed nested geography input.
 
 ## 2.0.7
 

--- a/RELEASE_NOTES_GUIDELINES.md
+++ b/RELEASE_NOTES_GUIDELINES.md
@@ -1,6 +1,6 @@
 # Release Notes Guidelines
 
-Use this guide only when a task needs a `.changeset/*.md` file or a `CHANGELOG.md` update.
+Use this guide when a task needs a `.changeset/*.md` file or explicit changelog maintenance.
 
 ## When release notes are required
 
@@ -19,7 +19,7 @@ Do not create or update release notes for changes that are only:
 
 ## Shared writing rules
 
-Apply these rules to both `.changeset/*.md` files and `CHANGELOG.md`:
+Apply these rules to `.changeset/*.md` files and any manual changelog maintenance:
 
 - Use plain English.
 - Do not use emojis.
@@ -57,24 +57,21 @@ Additional rules:
 
 ## Changelog rules
 
-Keep `CHANGELOG.md` in this structure:
+Changesets release PRs own generated `CHANGELOG.md` version sections. During
+normal feature and fix work:
 
-1. Keep `## [Unreleased]` at the top.
-2. Add entries under one of these headings only:
-   - `### Added`
-   - `### Changed`
-   - `### Deprecated`
-   - `### Removed`
-   - `### Fixed`
-   - `### Security`
-3. On release, move `Unreleased` items into a new version section:
-   - `## [x.y.z] - YYYY-MM-DD`
-4. After a release, reset `## [Unreleased]` to:
-   - `No unreleased user-facing or package-impacting changes.`
+1. Do not manually add version sections or duplicate `.changeset/*.md` entries in
+   `CHANGELOG.md`.
+2. Keep pending package release notes in `.changeset/*.md`; the release PR
+   generates the package version section.
+3. Edit `CHANGELOG.md` manually only for explicit changelog maintenance, such as
+   removing stale duplicate entries or correcting generated history.
+4. Preserve published history when cleaning the changelog, and do not invent
+   release dates.
 
 ## Relationship between changesets and the changelog
 
-- Keep the `.changeset/*.md` entry and the `CHANGELOG.md` entry aligned.
-- The changeset exists for versioning, release PRs, and GitHub release text.
-- `CHANGELOG.md` exists for human-readable project history.
+- The `.changeset/*.md` entry is the source of pending package release notes.
+- Changesets release PRs generate package version sections and release text.
+- `CHANGELOG.md` exists for published project history.
 - If a change does not need a changeset, it usually does not need a changelog entry either.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are supported for the latest published npm release line of
+`@vnedyalk0v/react19-simple-maps`.
+
+Older release lines do not receive separate security maintenance unless that
+support is explicitly documented. Upgrade to the latest npm version before
+reporting a suspected vulnerability when practical.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for a suspected vulnerability.
+
+Prefer GitHub private vulnerability reporting when it is enabled for this
+repository. If private reporting is unavailable, contact the maintainer through
+the private contact channel listed in the package metadata or maintainer
+profile.
+
+Include:
+
+- affected package version
+- supported runtime or browser where the issue was observed
+- minimal reproduction steps
+- expected impact
+
+Reports are triaged against the supported release policy above.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -26,7 +26,12 @@ Runs on:
 - PRs to `main`
 - pushes to `dev`
 
-The workflow installs dependencies and uses the canonical validation command:
+The workflow installs dependencies with lifecycle scripts disabled and uses the
+canonical validation command:
+
+```bash
+npm ci --ignore-scripts
+```
 
 ```bash
 npm run ci
@@ -46,9 +51,12 @@ npm run ci
 The CI orchestration itself lives in `.github/workflows/ci.yml`, which defines:
 
 - the `validate` job, running `npm run ci` under a Node.js matrix (`20`, `22`)
-- the `example-builds` job, which builds both examples separately to verify they work with the package
+- the `example-builds` job, which builds the root package explicitly, installs
+  each example with lifecycle scripts disabled, and builds both examples
+  separately to verify they work with the package
 
-This keeps local validation and GitHub validation aligned while keeping the command behavior and workflow job behavior distinct.
+This keeps dependency installation free of package builds while making
+`npm run ci` the explicit package validation and build contract.
 
 ## Release workflow
 
@@ -108,6 +116,22 @@ npm run release
 - Let Changesets manage release PR and version or changelog updates.
 - Do not bypass required checks on `dev` or `main`.
 - Keep pinned GitHub Action SHAs updated periodically.
+
+## Repository settings follow-ups
+
+These operational settings are tracked outside the repository and should be
+verified in GitHub or npm settings:
+
+- Configure npm trusted publishing for the release workflow and remove
+  `NPM_TOKEN` once trusted publishing is active.
+- Require the `Dependency Review` workflow, or fold dependency review into the
+  required `ci` check.
+- Set default GitHub Actions workflow permissions to read-only.
+- Enable enforcement for SHA-pinned GitHub Actions.
+- Enable automatic branch deletion after merge.
+- Decide the required review policy for protected branches.
+- Enable GitHub Issues for the repository.
+- Enable the repository security policy and private vulnerability reporting.
 
 ## Maintenance note
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "tsc --project tsconfig.build.json && NODE_ENV=production rollup -c",
     "build:types": "tsc --project tsconfig.build.json",
     "watch": "rollup -cw",
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/src/utils/geography-processing.ts
+++ b/src/utils/geography-processing.ts
@@ -195,6 +195,22 @@ export function prepareMesh(
   return result;
 }
 
+function getFeatureRsmKey(feature: Feature<Geometry>, index: number): string {
+  const existingKey = (
+    feature as Feature<Geometry> & { rsmKey?: string | number }
+  ).rsmKey;
+
+  if (existingKey !== undefined && existingKey !== null) {
+    return String(existingKey);
+  }
+
+  if (feature.id !== undefined && feature.id !== null) {
+    return String(feature.id);
+  }
+
+  return `geo-${index}`;
+}
+
 /**
  * Prepares features by generating SVG paths for each feature
  * @param features - Array of features to prepare
@@ -210,7 +226,7 @@ export function prepareFeatures(
   }
 
   return features
-    .map((feature) => {
+    .map((feature, index) => {
       const svgPath = path(feature);
       if (!svgPath) {
         return null;
@@ -219,6 +235,7 @@ export function prepareFeatures(
       return {
         ...feature,
         svgPath,
+        rsmKey: getFeatureRsmKey(feature, index),
       } as PreparedFeature;
     })
     .filter((feature): feature is PreparedFeature => feature !== null);

--- a/src/utils/geography-processing.ts
+++ b/src/utils/geography-processing.ts
@@ -195,7 +195,7 @@ export function prepareMesh(
   return result;
 }
 
-function getFeatureRsmKey(feature: Feature<Geometry>, index: number): string {
+function getExplicitFeatureKey(feature: Feature<Geometry>): string | null {
   const existingKey = (
     feature as Feature<Geometry> & { rsmKey?: string | number }
   ).rsmKey;
@@ -208,7 +208,26 @@ function getFeatureRsmKey(feature: Feature<Geometry>, index: number): string {
     return String(feature.id);
   }
 
-  return `geo-${index}`;
+  return null;
+}
+
+function getUniqueFallbackRsmKey(
+  index: number,
+  unavailableKeys: Set<string>,
+): string {
+  const baseKey = `geo-${index}`;
+  if (!unavailableKeys.has(baseKey)) {
+    return baseKey;
+  }
+
+  let suffix = 1;
+  let fallbackKey = `${baseKey}-${suffix}`;
+  while (unavailableKeys.has(fallbackKey)) {
+    suffix += 1;
+    fallbackKey = `${baseKey}-${suffix}`;
+  }
+
+  return fallbackKey;
 }
 
 /**
@@ -225,7 +244,7 @@ export function prepareFeatures(
     return [];
   }
 
-  return features
+  const preparedCandidates = features
     .map((feature, index) => {
       const svgPath = path(feature);
       if (!svgPath) {
@@ -233,12 +252,31 @@ export function prepareFeatures(
       }
 
       return {
-        ...feature,
+        explicitKey: getExplicitFeatureKey(feature),
+        feature,
+        index,
         svgPath,
-        rsmKey: getFeatureRsmKey(feature, index),
-      } as PreparedFeature;
+      };
     })
-    .filter((feature): feature is PreparedFeature => feature !== null);
+    .filter((feature) => feature !== null);
+
+  const unavailableKeys = new Set(
+    preparedCandidates
+      .map((candidate) => candidate.explicitKey)
+      .filter((rsmKey): rsmKey is string => rsmKey !== null),
+  );
+
+  return preparedCandidates.map(({ explicitKey, feature, index, svgPath }) => {
+    const rsmKey =
+      explicitKey ?? getUniqueFallbackRsmKey(index, unavailableKeys);
+    unavailableKeys.add(rsmKey);
+
+    return {
+      ...feature,
+      svgPath,
+      rsmKey,
+    } as PreparedFeature;
+  });
 }
 
 /**

--- a/src/utils/geography-processing.ts
+++ b/src/utils/geography-processing.ts
@@ -211,23 +211,49 @@ function getExplicitFeatureKey(feature: Feature<Geometry>): string | null {
   return null;
 }
 
-function getUniqueFallbackRsmKey(
-  index: number,
-  unavailableKeys: Set<string>,
+function isKeyUnavailable(
+  key: string,
+  unavailableKeySets: Set<string>[],
+): boolean {
+  return unavailableKeySets.some((unavailableKeys) => unavailableKeys.has(key));
+}
+
+function getUniqueRsmKey(
+  baseKey: string,
+  unavailableKeySets: Set<string>[],
 ): string {
-  const baseKey = `geo-${index}`;
-  if (!unavailableKeys.has(baseKey)) {
+  if (!isKeyUnavailable(baseKey, unavailableKeySets)) {
     return baseKey;
   }
 
   let suffix = 1;
   let fallbackKey = `${baseKey}-${suffix}`;
-  while (unavailableKeys.has(fallbackKey)) {
+  while (isKeyUnavailable(fallbackKey, unavailableKeySets)) {
     suffix += 1;
     fallbackKey = `${baseKey}-${suffix}`;
   }
 
   return fallbackKey;
+}
+
+function getUniqueExplicitRsmKey(
+  explicitKey: string,
+  usedKeys: Set<string>,
+  reservedExplicitKeys: Set<string>,
+): string {
+  if (!usedKeys.has(explicitKey)) {
+    return explicitKey;
+  }
+
+  return getUniqueRsmKey(explicitKey, [usedKeys, reservedExplicitKeys]);
+}
+
+function getUniqueFallbackRsmKey(
+  index: number,
+  usedKeys: Set<string>,
+  reservedExplicitKeys: Set<string>,
+): string {
+  return getUniqueRsmKey(`geo-${index}`, [usedKeys, reservedExplicitKeys]);
 }
 
 /**
@@ -260,16 +286,19 @@ export function prepareFeatures(
     })
     .filter((feature) => feature !== null);
 
-  const unavailableKeys = new Set(
+  const reservedExplicitKeys = new Set(
     preparedCandidates
       .map((candidate) => candidate.explicitKey)
       .filter((rsmKey): rsmKey is string => rsmKey !== null),
   );
+  const usedKeys = new Set<string>();
 
   return preparedCandidates.map(({ explicitKey, feature, index, svgPath }) => {
     const rsmKey =
-      explicitKey ?? getUniqueFallbackRsmKey(index, unavailableKeys);
-    unavailableKeys.add(rsmKey);
+      explicitKey !== null
+        ? getUniqueExplicitRsmKey(explicitKey, usedKeys, reservedExplicitKeys)
+        : getUniqueFallbackRsmKey(index, usedKeys, reservedExplicitKeys);
+    usedKeys.add(rsmKey);
 
     return {
       ...feature,

--- a/tests/geographies-integration.test.tsx
+++ b/tests/geographies-integration.test.tsx
@@ -102,6 +102,33 @@ describe('Geographies integration', () => {
     expect(new Set(rsmKeys).size).toBe(rsmKeys.length);
   });
 
+  it('disambiguates duplicate explicit feature keys', () => {
+    const keyedFeatures = [
+      {
+        ...featureCollection.features[0],
+        rsmKey: 'same-key',
+      },
+      {
+        ...featureCollection.features[0],
+        rsmKey: 'same-key',
+      },
+      {
+        ...featureCollection.features[0],
+        id: 'same-id',
+      },
+      {
+        ...featureCollection.features[0],
+        id: 'same-id',
+      },
+    ];
+
+    const prepared = prepareFeatures(keyedFeatures, geoPath());
+    const rsmKeys = prepared.map((geo) => geo.rsmKey);
+
+    expect(rsmKeys).toEqual(['same-key', 'same-key-1', 'same-id', 'same-id-1']);
+    expect(new Set(rsmKeys).size).toBe(rsmKeys.length);
+  });
+
   it('recomputes prepared SVG paths when the projection changes', async () => {
     const { container, rerender } = render(
       <ComposableMap projection="geoEqualEarth">

--- a/tests/geographies-integration.test.tsx
+++ b/tests/geographies-integration.test.tsx
@@ -1,9 +1,11 @@
 import { render, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { FeatureCollection, Geometry } from 'geojson';
+import { geoPath } from 'd3-geo';
 import ComposableMap from '../src/components/ComposableMap';
 import Geographies from '../src/components/Geographies';
 import Geography from '../src/components/Geography';
+import { prepareFeatures } from '../src/utils/geography-processing';
 
 const featureCollection: FeatureCollection<Geometry> = {
   type: 'FeatureCollection',
@@ -35,7 +37,11 @@ describe('Geographies integration', () => {
           {({ geographies }) => (
             <>
               {geographies.map((geo) => (
-                <Geography key={geo.rsmKey} geography={geo} />
+                <Geography
+                  key={geo.rsmKey}
+                  geography={geo}
+                  data-rsm-key={geo.rsmKey}
+                />
               ))}
             </>
           )}
@@ -49,6 +55,30 @@ describe('Geographies integration', () => {
 
     const renderedPath = container.querySelector('path.rsm-geography');
     expect(renderedPath?.getAttribute('d')).toBeTruthy();
+    expect(renderedPath?.getAttribute('data-rsm-key')).toBe('geo-0');
+  });
+
+  it('assigns stable prepared feature keys from rsmKey, id, then index', () => {
+    const keyedFeatures = [
+      {
+        ...featureCollection.features[0],
+        id: 'ignored-id',
+        rsmKey: 'existing-key',
+      },
+      {
+        ...featureCollection.features[0],
+        id: 'feature-id',
+      },
+      featureCollection.features[0],
+    ];
+
+    const prepared = prepareFeatures(keyedFeatures, geoPath());
+
+    expect(prepared.map((geo) => geo.rsmKey)).toEqual([
+      'existing-key',
+      'feature-id',
+      'geo-2',
+    ]);
   });
 
   it('recomputes prepared SVG paths when the projection changes', async () => {

--- a/tests/geographies-integration.test.tsx
+++ b/tests/geographies-integration.test.tsx
@@ -81,6 +81,27 @@ describe('Geographies integration', () => {
     ]);
   });
 
+  it('disambiguates fallback keys from existing feature keys', () => {
+    const keyedFeatures = [
+      {
+        ...featureCollection.features[0],
+        rsmKey: 'geo-1',
+      },
+      featureCollection.features[0],
+      {
+        ...featureCollection.features[0],
+        id: 'geo-2',
+      },
+      featureCollection.features[0],
+    ];
+
+    const prepared = prepareFeatures(keyedFeatures, geoPath());
+    const rsmKeys = prepared.map((geo) => geo.rsmKey);
+
+    expect(rsmKeys).toEqual(['geo-1', 'geo-1-1', 'geo-2', 'geo-3']);
+    expect(new Set(rsmKeys).size).toBe(rsmKeys.length);
+  });
+
   it('recomputes prepared SVG paths when the projection changes', async () => {
     const { container, rerender } = render(
       <ComposableMap projection="geoEqualEarth">


### PR DESCRIPTION
## Summary

- Promotes the prepared geography key fixes from `dev` to `main`.
- Promotes CI install changes that avoid package builds during `npm ci`.
- Promotes release-note guidance cleanup and the root security policy.

## Impact

- Consumers using `key={geo.rsmKey}` get stable, unique keys for prepared geographies.
- CI installs are faster and more predictable because package builds run in explicit validation steps, not install lifecycle scripts.
- Release/security docs are clearer; live repository settings still need separate follow-up outside this PR.

## Validation

- `dev` CI passed on `969c46fb80ba3e6ffcf8d088cd93f8800c9b24dd`.
- PR #142 checks passed before merge.
- PR #143 checks passed before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Geographies now expose stable, collision-free keys for React lists; existing keys are preserved and duplicates are disambiguated.

* **Documentation**
  * Added a security policy and vulnerability reporting guide.
  * Updated release notes/changelog guidance and CI/CD documentation.

* **Chores**
  * CI installs now run with lifecycle scripts disabled for validation.
  * Adjusted package build lifecycle hook configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->