### PR TITLE
Restore 2.0.8 changelog history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Patch Changes
 
-- Updated development tooling and release workflow maintenance without changing the public runtime API.
+- Hardened geography validation and cache isolation.
+  - Blocks prototype-mutation payloads during object validation and avoids inherited-value reads in projection and security config parsing.
+  - Replaces collision-prone geography cache keys with object-identity-based keys so different datasets or parsing functions do not reuse the wrong cached results.
+  - Applies the hardened geography URL validation pipeline to `generateSRIHash`.
+  - Adds safer default geography error messaging.
+  - Fails more predictably on malformed nested geography input.
 
 ## 2.0.7
 


### PR DESCRIPTION
## Summary

- Restores the already-published 2.0.8 changelog entry to the geography security/cache hardening notes.
- Keeps the release-note ownership cleanup intact while preserving published package history.

## Impact

- Users looking up version 2.0.8 see the correct shipped fixes again.
- No runtime, package API, or workflow behavior changes.

## Validation

- `npm run check-format`
- `git diff --check`