### PR TITLE
Fix duplicate explicit geography keys

### DIFF
--- a/.changeset/unique-geography-fallback-keys.md
+++ b/.changeset/unique-geography-fallback-keys.md
@@ -5,3 +5,4 @@
 Synthesized prepared geography keys now avoid collisions with existing feature keys.
 
 - Fallback `rsmKey` values keep React list keys unique when a GeoJSON `id` or existing `rsmKey` already uses the same `geo-*` shape.
+- Duplicate explicit `rsmKey` and GeoJSON `id` values are also disambiguated with stable suffixes.

--- a/src/utils/geography-processing.ts
+++ b/src/utils/geography-processing.ts
@@ -211,23 +211,49 @@ function getExplicitFeatureKey(feature: Feature<Geometry>): string | null {
   return null;
 }
 
-function getUniqueFallbackRsmKey(
-  index: number,
-  unavailableKeys: Set<string>,
+function isKeyUnavailable(
+  key: string,
+  unavailableKeySets: Set<string>[],
+): boolean {
+  return unavailableKeySets.some((unavailableKeys) => unavailableKeys.has(key));
+}
+
+function getUniqueRsmKey(
+  baseKey: string,
+  unavailableKeySets: Set<string>[],
 ): string {
-  const baseKey = `geo-${index}`;
-  if (!unavailableKeys.has(baseKey)) {
+  if (!isKeyUnavailable(baseKey, unavailableKeySets)) {
     return baseKey;
   }
 
   let suffix = 1;
   let fallbackKey = `${baseKey}-${suffix}`;
-  while (unavailableKeys.has(fallbackKey)) {
+  while (isKeyUnavailable(fallbackKey, unavailableKeySets)) {
     suffix += 1;
     fallbackKey = `${baseKey}-${suffix}`;
   }
 
   return fallbackKey;
+}
+
+function getUniqueExplicitRsmKey(
+  explicitKey: string,
+  usedKeys: Set<string>,
+  reservedExplicitKeys: Set<string>,
+): string {
+  if (!usedKeys.has(explicitKey)) {
+    return explicitKey;
+  }
+
+  return getUniqueRsmKey(explicitKey, [usedKeys, reservedExplicitKeys]);
+}
+
+function getUniqueFallbackRsmKey(
+  index: number,
+  usedKeys: Set<string>,
+  reservedExplicitKeys: Set<string>,
+): string {
+  return getUniqueRsmKey(`geo-${index}`, [usedKeys, reservedExplicitKeys]);
 }
 
 /**
@@ -260,16 +286,19 @@ export function prepareFeatures(
     })
     .filter((feature) => feature !== null);
 
-  const unavailableKeys = new Set(
+  const reservedExplicitKeys = new Set(
     preparedCandidates
       .map((candidate) => candidate.explicitKey)
       .filter((rsmKey): rsmKey is string => rsmKey !== null),
   );
+  const usedKeys = new Set<string>();
 
   return preparedCandidates.map(({ explicitKey, feature, index, svgPath }) => {
     const rsmKey =
-      explicitKey ?? getUniqueFallbackRsmKey(index, unavailableKeys);
-    unavailableKeys.add(rsmKey);
+      explicitKey !== null
+        ? getUniqueExplicitRsmKey(explicitKey, usedKeys, reservedExplicitKeys)
+        : getUniqueFallbackRsmKey(index, usedKeys, reservedExplicitKeys);
+    usedKeys.add(rsmKey);
 
     return {
       ...feature,

--- a/tests/geographies-integration.test.tsx
+++ b/tests/geographies-integration.test.tsx
@@ -102,6 +102,33 @@ describe('Geographies integration', () => {
     expect(new Set(rsmKeys).size).toBe(rsmKeys.length);
   });
 
+  it('disambiguates duplicate explicit feature keys', () => {
+    const keyedFeatures = [
+      {
+        ...featureCollection.features[0],
+        rsmKey: 'same-key',
+      },
+      {
+        ...featureCollection.features[0],
+        rsmKey: 'same-key',
+      },
+      {
+        ...featureCollection.features[0],
+        id: 'same-id',
+      },
+      {
+        ...featureCollection.features[0],
+        id: 'same-id',
+      },
+    ];
+
+    const prepared = prepareFeatures(keyedFeatures, geoPath());
+    const rsmKeys = prepared.map((geo) => geo.rsmKey);
+
+    expect(rsmKeys).toEqual(['same-key', 'same-key-1', 'same-id', 'same-id-1']);
+    expect(new Set(rsmKeys).size).toBe(rsmKeys.length);
+  });
+
   it('recomputes prepared SVG paths when the projection changes', async () => {
     const { container, rerender } = render(
       <ComposableMap projection="geoEqualEarth">


### PR DESCRIPTION
## Summary

- Disambiguates duplicate explicit `rsmKey` and GeoJSON `id` values when preparing geographies.
- Preserves the first explicit key and adds stable suffixes to later duplicates.
- Updates regression coverage and the pending changeset.

## Impact

- Consumers using `key={geo.rsmKey}` avoid duplicate React keys even when source data repeats IDs.
- No public API shape changes.

## Validation

- `npm test -- tests/geographies-integration.test.tsx` (red before implementation, green after)
- `npm run ci`
- `npm pack --dry-run --json --ignore-scripts`
- `git diff --check`