### PR TITLE
fix(build): preserve @vite-ignore annotation in bundle

### DIFF
--- a/.changeset/zoom-cleanup-and-side-effects.md
+++ b/.changeset/zoom-cleanup-and-side-effects.md
@@ -1,0 +1,9 @@
+---
+'@vnedyalk0v/react19-simple-maps': patch
+---
+
+Fixed a d3-zoom listener leak and restored the `sideEffects: false` contract.
+
+- `useZoomBehavior` now detaches `.zoom` namespace listeners on effect cleanup, so pointer, wheel, and touch handlers no longer outlive the effect across Strict Mode re-runs and unmount.
+- Removed a top-level `globalThis.__MAP_DEBUGGER__` write that ran at import time, violating the package's `sideEffects: false` declaration and blocking tree-shaking.
+- The published bundle now preserves the `/* @vite-ignore */` annotation on the guarded `node:dns/promises` import, so downstream Vite projects no longer emit a dynamic-import warning.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -69,7 +69,9 @@ const esmTerserConfig = {
     },
   },
   format: {
-    comments: false,
+    // Keep /* @vite-ignore */ so downstream Vite builds don't warn on the
+    // guarded node:dns/promises dynamic import; strip everything else.
+    comments: /@vite-ignore/,
     beautify: false,
     ascii_only: false,
     semicolons: true,


### PR DESCRIPTION
## The bug

`src/utils/geography-validation.ts` carries a `/* @vite-ignore */` annotation on its guarded `node:dns/promises` dynamic import. But `rollup.config.js` ran terser with `format.comments: false`, which stripped **every** comment from the bundle — including that one.

Result: Vite could no longer see the annotation, so every downstream project consuming `dist/index.js` got this on dev server startup:

```
The above dynamic import cannot be analyzed by Vite.
  const t = "node:dns/promises", e = await import(t);
```

Found while browser-testing the examples against the built `dist`.

## The fix

Narrow the terser comment filter to a regex matching only `@vite-ignore`.

Verified after rebuild:
- annotation survives into `dist/index.js` — `await import(/* @vite-ignore */ t)`
- it is the **only** comment in the bundle, so nothing else leaked back in
- restarting `examples/interactive-map` with a cleared Vite cache: warning gone

The runtime code was already correct and needed no change. That DNS path is SSRF hardening, gated behind `process.release?.name === 'node' && typeof window === 'undefined'`, so it never executes in a browser.

## Changeset

Queues a **patch** covering three unreleased, user-visible changes. Note that #177 landed on `dev` without a changeset — so without this, its zoom fix would have shipped silently with no version bump and no changelog entry.

- d3-zoom listener leak: `useZoomBehavior` bound pointer/wheel/touch handlers via `svg.call(zoomBehavior)` but never returned a cleanup, leaving `.zoom` listeners attached beyond the effect's lifetime across Strict Mode re-runs and unmount
- `sideEffects: false` violation: a top-level `globalThis.__MAP_DEBUGGER__` write ran at import time, breaking the tree-shaking contract the package declares
- this `@vite-ignore` fix

Patch is correct — the public export surface is identical between `main` and `dev`. The ~1,700 lines #177 deleted (`performance.ts`, `concurrentOptimizer.ts`, nine `input-validation` helpers, dead `MapDebugger` surface) were never exported from `index.ts` or `utils.ts`.

## Verification

`npm run ci` green. Beyond that, both examples were driven in real headless Chromium against the built `dist`:

- interactive-map — 21/21: 242 geographies with 0 NaN paths, all 6 markers projected, country hover/click, city click with data binding, zoom via prop and scroll wheel, drag pan, all three projections, marker toggle, and a rapid projection/nav churn pass for effect-cleanup regressions. 0 exceptions, 0 console errors, 0 failed requests.
- basic-map — 178 geographies, 0 NaN, clean console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)