### PR TITLE
fix(ci): make main->dev sync PRs actually mergeable

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -18,26 +18,55 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Create sync PR when main is ahead of dev
-        id: sync_pr
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: dev
+
+      - name: Create back-merge branch when main is ahead of dev
+        id: sync
+        run: |
+          set -euo pipefail
+
+          if git merge-base --is-ancestor origin/main origin/dev; then
+            echo "No sync needed: dev already contains main."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$SYNC_BRANCH" origin/dev
+
+          # --no-ff is required, not stylistic. dev is normally a strict ancestor of
+          # main, so a fast-forward would leave this branch's tip identical to main's
+          # SHA. GitHub creates no pull_request workflow run for a SHA that is already
+          # another branch's tip, so the required ci / dependency-review checks would
+          # never report and the PR would be permanently unmergeable under
+          # protect-dev. A real merge commit gives CI a fresh SHA to run against.
+          if ! git merge --no-ff origin/main -m "chore: sync main into dev"; then
+            echo "::error::Merge conflict syncing main into dev; resolve manually."
+            exit 1
+          fi
+
+          git push --force-with-lease origin "$SYNC_BRANCH"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+        env:
+          SYNC_BRANCH: sync/main-to-dev
+
+      - name: Open or reuse sync PR, then auto-merge
+        if: steps.sync.outputs.created == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SYNC_BRANCH: sync/main-to-dev
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const base = "dev";
-            const head = "main";
-
-            const compare = await github.rest.repos.compareCommitsWithBasehead({
-              owner,
-              repo,
-              basehead: `${base}...${head}`,
-            });
-
-            if (compare.data.status === "identical" || compare.data.ahead_by === 0) {
-              core.info("No sync needed: main is not ahead of dev.");
-              return;
-            }
+            const head = process.env.SYNC_BRANCH;
 
             const existing = await github.rest.pulls.list({
               owner,
@@ -48,49 +77,31 @@ jobs:
               per_page: 1,
             });
 
-            if (existing.data.length > 0) {
-              const existingPr = existing.data[0];
-              core.info(`Sync PR already open: #${existingPr.number}`);
-              core.setOutput("pr_number", String(existingPr.number));
-              return;
-            }
+            let pr = existing.data[0];
 
-            const pr = await github.rest.pulls.create({
-              owner,
-              repo,
-              title: "chore: sync main into dev",
-              head,
-              base,
-              body: [
-                "Automated sync PR to keep `dev` up to date with `main`.",
-                "",
-                "- Trigger: push to `main`",
-                "- Source: `main`",
-                "- Target: `dev`",
-              ].join("\n"),
-            });
-
-            core.info(`Created PR #${pr.data.number}: ${pr.data.html_url}`);
-            core.setOutput("pr_number", String(pr.data.number));
-
-      - name: Enable auto-merge for sync PR
-        if: steps.sync_pr.outputs.pr_number != ''
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prNumber = Number("${{ steps.sync_pr.outputs.pr_number }}");
-
-            const pr = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: prNumber,
-            });
-
-            if (pr.data.state !== "open") {
-              core.info(`PR #${prNumber} is already ${pr.data.state}.`);
-              return;
+            if (pr) {
+              core.info(`Reusing open sync PR #${pr.number}`);
+            } else {
+              const created = await github.rest.pulls.create({
+                owner,
+                repo,
+                title: "chore: sync main into dev",
+                head,
+                base,
+                body: [
+                  "Automated back-merge to keep `dev` up to date with `main`.",
+                  "",
+                  "- Trigger: push to `main`",
+                  "- Source: `main` (merged with `--no-ff`)",
+                  "- Target: `dev`",
+                  "",
+                  "The merge commit is deliberate. A direct `main` -> `dev` PR carries a head SHA",
+                  "identical to `main`'s tip, which GitHub never generates a `pull_request` run for,",
+                  "leaving the required checks unreportable and the PR permanently blocked.",
+                ].join("\n"),
+              });
+              pr = created.data;
+              core.info(`Created PR #${pr.number}: ${pr.html_url}`);
             }
 
             try {
@@ -102,11 +113,9 @@ jobs:
                     }
                   }
                 }`,
-                {
-                  pullRequestId: pr.data.node_id,
-                }
+                { pullRequestId: pr.node_id }
               );
-              core.info(`Enabled auto-merge for PR #${prNumber}.`);
+              core.info(`Enabled auto-merge for PR #${pr.number}.`);
             } catch (error) {
-              core.warning(`Could not enable auto-merge for PR #${prNumber}: ${error.message}`);
+              core.warning(`Could not enable auto-merge for PR #${pr.number}: ${error.message}`);
             }


### PR DESCRIPTION
The `Sync main -> dev` workflow has been producing permanently unmergeable PRs. #223 is the current one.

## The bug

It opened its PR with `head=main, base=dev`. Since `dev` is normally a strict ancestor of `main`, that PR's head SHA **is** `main`'s own tip — and GitHub creates no `pull_request` workflow run for a SHA already sitting at the tip of another branch.

`protect-dev` requires `ci` and `dependency-review`. Those checks could never report, so the PR sat at `BLOCKED` forever. Close/reopen doesn't help. And `protect-dev` has **zero bypass actors** (deliberately — `protect-main` has an admin bypass, `dev` does not), so there was no way to merge one without weakening the ruleset.

This is why `dev` had drifted out of sync and why #219 had to be abandoned and redone as #220.

## The fix

Build the sync on a branch instead of pointing at `main` directly:

```
git checkout -B sync/main-to-dev origin/dev
git merge --no-ff origin/main
```

The `--no-ff` is load-bearing, not stylistic — a fast-forward would reproduce exactly the SHA collision above. The merge commit gives CI a fresh SHA to run against while the tree stays byte-identical to `main`.

Also:
- skip detection switches from the compare API to `git merge-base --is-ancestor origin/main origin/dev`, which asks the actual question: does `dev` already contain `main`
- merge conflicts now fail loudly with `::error::` instead of surfacing as a mysterious API failure
- the branch name is fixed and force-pushed, so at most one sync branch ever exists
- auto-merge behaviour is unchanged

## Why this shape rather than the alternative

The cleaner-on-paper option is adding the Actions bot as a `protect-dev` bypass actor and fast-forwarding `dev` with no PR at all — a pure fast-forward has no new content to review. That was rejected because `dev` is the one branch deliberately left without any bypass. This fix works entirely inside the existing protections and changes no repository settings.

A `--no-ff` back-merge is also just standard practice for syncing a release branch back into an integration branch, so the merge commit is meaningful history rather than noise.

## Verification

Replayed the exact sequence against the live branches:

```
origin/main: d56f3c4   origin/dev: cb3e707
branch tip : 815620b   ← differs from main's SHA, so CI generates a run
content vs main: IDENTICAL
```

YAML parses, prettier clean.

## Follow-ups

- **#223 should be closed** — it's the last PR from the broken shape and can never merge.
- `delete_branch_on_merge` is `false` on this repo, so `sync/main-to-dev` will linger after each merge. Harmless (it's reused and force-pushed), but enabling that setting would keep the branch list at just `main` and `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)