### PR TITLE
docs: add agent guidelines and fix doc mismatches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,145 +1,125 @@
-# react19-simple-maps Project Guidelines
+# react19-simple-maps — Agent Guidelines
 
-This repository publishes a React 19+ npm package, not an application.
+This repo publishes a React 19+ ESM npm package (`@vnedyalk0v/react19-simple-maps`), not an application. Optimize for: stable public API, small bundle, tree-shakeable output, SSR- and Strict Mode-safe behavior, predictable releases.
 
-When making changes, optimize for:
+Prefer KISS and DRY. No app-like abstractions, no speculative architecture, no bloat. Extend existing APIs and reuse existing helpers before adding new ones. Add a dependency only when the same result is not achievable with the current stack or a small local utility.
 
-- a stable public API
-- small runtime and bundle size
-- tree-shakeable ESM output
-- SSR-safe and Strict Mode-safe behavior
-- clear documentation and predictable release notes
+## Layout
 
-Prefer KISS and DRY. Do not add bloatware, app-like abstractions, or speculative architecture.
+- `src/` — library code (`components/`, `hooks/`, `utils/`, `index.ts`, `utils.ts`, `types.ts`)
+- `tests/` — Vitest suites (jsdom)
+- `examples/basic-map`, `examples/interactive-map` — standalone apps built in CI
+- `scripts/` — bundle analysis, SRI generation, build verification
+- `docs/ci-cd.md`, `docs/support.md`, `RELEASE_NOTES_GUIDELINES.md` — read on demand only
 
-These rules apply when editing library code in `src/` and docs/examples in `examples/`.
+## Commands
 
-## Project Mindset (Required)
-
-- Treat this repo as a reusable library consumed by many apps with different stacks.
-- Do not bake in app-specific assumptions about routing, state management, styling frameworks, analytics, or data frameworks.
-- Prefer extending existing APIs and utilities over introducing new abstraction layers.
-- Reuse existing helpers before adding new ones. Avoid ad hoc local duplicates of existing coordinate, validation, fetch, or security utilities.
-- Only add new dependencies when the value is clear and the same result cannot be achieved with the current stack or a small local utility.
+- `npm run ci` — canonical gate: build, type-check, lint, format check, tests, build verification
+- `npm test` / `npm run test:coverage` — Vitest
+- `npm run lint:fix`, `npm run format` — autofix
+- `npm run analyze` — bundle size report
+- `npm run generate-sri` — regenerate `scripts/sri-hashes.json` and `src/utils/generated-sri-hashes.ts`
+- Examples: `cd examples/<name> && npm ci --ignore-scripts && npm run build`
 
 ## Git Workflow (Required)
 
-- Never push directly to `main`.
-- For every task, create a new branch from `dev`.
-- Before branching, update `dev` from remote so it is current with `origin/dev`.
-- Keep all task work on that new branch and open a PR to merge.
-- After a PR is merged, do not continue follow-up work on that branch. Create a new branch from updated `dev`.
-- Before claiming a fix is in `dev` or in a specific PR, verify the current git and GitHub state instead of relying on memory or prior conversation context.
-- If review feedback arrives after merge, treat it as a new task: branch from current `dev`, apply the fix, validate it, and open a new PR.
+- `dev` is the integration branch; `main` is the release branch. Never push directly to either.
+- For every task: update `dev` from `origin/dev`, branch from it, keep work scoped to the request, open a PR into `dev`.
+- After a PR merges, do not continue on that branch. Branch fresh from updated `dev` — including for post-merge review feedback.
+- Conventional Commits (`fix(build): ...`, `chore(deps): ...`).
+- Before claiming a fix is in `dev` or in a PR, verify actual git/GitHub state rather than relying on memory.
 
-## Local Workflow (Required)
+## Before Pushing (Required)
 
-- Start from updated `dev`, create a fresh task branch, and keep the change scoped to the user request.
-- Run the most relevant local validation before commit. Use `npm run ci` as the default package gate; add targeted tests, example builds, `npm run analyze`, `npm pack --dry-run`, or generator checks when the touched area requires them.
-- Before committing or pushing, run CodeRabbit CLI as the final local review and wait for it to finish:
+1. Run `npm run ci`. Add targeted checks when the touched area needs them: example builds, `npm run analyze`, `npm pack --dry-run`, generator reruns.
+2. Run CodeRabbit CLI as the final local review and wait for it to finish:
 
-```bash
-cr review --agent --type uncommitted --base dev
-```
+   ```bash
+   cr review --agent --type uncommitted --base dev
+   ```
 
-- `coderabbit review --agent --type uncommitted --base dev` is equivalent when the `cr` alias is unavailable.
-- Treat CodeRabbit findings as review input, not automatic truth. Verify each finding against the current code, fix valid issues, and rerun CodeRabbit after fixes.
-- Commit and push only after validation passes and CodeRabbit has no remaining valid recommendations.
-- If CodeRabbit cannot run because authentication, installation, or service connectivity is broken, run `cr doctor`, report the blocker, and do not push unless the user explicitly approves bypassing this gate.
+   (`coderabbit review --agent --type uncommitted --base dev` if the `cr` alias is unavailable.)
+
+3. Treat findings as input, not truth. Verify each against current code, fix valid ones, rerun.
+4. Push only after validation passes and no valid recommendations remain. If CodeRabbit cannot run (auth, install, connectivity), run `cr doctor`, report the blocker, and do not push unless the user explicitly approves bypassing this gate.
+
+## Pull Request Review Gate (Required)
+
+Opening a PR automatically triggers **Codex Review** and **Greptile Review**. Never merge a PR before those reviews have completed. CodeRabbit does not auto-review PRs targeting `dev` — its auto-review is limited to the default branch — so the local `cr` gate above is its coverage. Comment `@coderabbitai review` to request it on a PR when that local run was skipped or blocked.
+
+1. Open the PR into `dev` and wait for the automated reviews to post. A PR with reviews still pending is not mergeable, regardless of CI status.
+2. If reviews are clean and required checks (`ci`, `dependency-review`) pass — merge.
+3. If any issue is flagged:
+   - Verify each finding against the current code. Reviewers can be wrong.
+   - Fix the valid ones on the same branch and push.
+   - Reply to every comment: what was fixed, or why the finding does not apply.
+   - Resolve the addressed threads.
+   - Request a fresh review by commenting `@codex review` and `@greptile review`.
+   - Wait for the new reviews to complete, then repeat from step 2.
+4. Merge only after a review round comes back with no outstanding issues and all required checks pass. Verify the merged state afterwards instead of assuming it.
+5. Never reference review bots or IDE names (CodeRabbit, Codex, Greptile, Cursor, Copilot) outside this file and PR review threads — not in changesets, changelog entries, commit messages, code comments, README, or docs.
 
 ## Release Notes (Required)
 
-- For every user-facing or package-impacting change, create a new `.changeset/*.md` file that follows `RELEASE_NOTES_GUIDELINES.md`.
-- The changeset file must describe the change clearly so Changesets can generate changelog entries and release text.
-- Do not manually update `CHANGELOG.md` for normal feature or fix work; Changesets release PRs own generated version sections.
-- Read `RELEASE_NOTES_GUIDELINES.md` only when the task requires a changeset or explicit changelog maintenance.
-- Do not update `CHANGELOG.md` for tooling-only, CI-only, lockfile-only, or other internal-only maintenance.
-- Never reference internal tooling, review bots, or IDE names (e.g., CodeRabbit, Cursor, Copilot) in changesets, changelog entries, commit messages, code comments, or any user-facing text. Describe _what_ changed and _why_, not which tool suggested it.
+- Every user-facing or package-impacting change needs a new `.changeset/*.md` file following `RELEASE_NOTES_GUIDELINES.md`.
+- Do not hand-edit `CHANGELOG.md`; Changesets release PRs own generated sections.
+- No changeset for tooling-only, CI-only, lockfile-only, docs-only, or other internal maintenance that does not change package behavior or supported usage.
 
-## Package Constraints (Required)
+## Package Constraints
 
-- Target React 19+ only (`peerDependencies` stay `>=19.0.0` unless explicitly changed).
-- Keep the package ESM-only and preserve the `exports` map in `package.json`.
-- Keep `sideEffects: false` valid. Avoid top-level work that produces observable side effects.
+- React 19+ only (`peerDependencies` stay `>=19.0.0` unless explicitly changed).
+- ESM-only; preserve the `exports` map in `package.json`.
+- Keep `sideEffects: false` valid — no top-level work with observable side effects.
 - Preserve tree-shakeability. Export only what belongs in the public API.
-- Keep browser-only APIs guarded. Do not assume `window`, `document`, `navigator`, or DOM availability during server rendering.
-- If you change the public API, also update types, README, examples, tests, and release notes in the same task.
-- Prefer additive changes. Do not break existing consumers unless a breaking change is explicitly requested.
-- Read `docs/support.md` only when the task affects support guarantees, platform compatibility, distribution channels, release expectations, or the public `./utils` API policy.
+- Guard browser-only APIs. Never assume `window`, `document`, `navigator`, or DOM during server rendering.
+- Prefer additive changes; do not break consumers unless a breaking change is explicitly requested.
+- A public API change must update types, README, examples, tests, and release notes in the same task.
 
-## React 19 Rules (Required)
+## React 19 Rules
 
-- Components and Hooks must stay pure and idempotent during render.
-- Never run side effects during render. Side effects belong in event handlers or Effects.
-- If there is no external system to synchronize with, do not add an Effect.
-- Do not mirror props or derived values into state unless there is a real state boundary. Derive values during render whenever possible.
-- Use `useMemo` only for measurably expensive calculations or to stabilize values that materially affect memoization or Effect behavior.
-- Use `memo` only as a performance optimization. Do not rely on it for correctness.
-- Prefer default shallow prop comparison for `memo`. Add custom comparators only when profiling shows a need and tests prove they do not hide legitimate updates.
-- Follow the existing `ref`-as-prop pattern. In React 19, prefer passing `ref` as a prop; use `forwardRef` only when unavoidable for compatibility or typing constraints.
-- If you need to subscribe to data that lives outside React, prefer `useSyncExternalStore` over ad hoc subscription Effects. Keep it SSR-safe when server rendering matters.
-- Code must behave correctly under Strict Mode and concurrent rendering. Effect cleanup must fully mirror setup.
+- Components and Hooks stay pure and idempotent during render. Side effects belong in event handlers or Effects.
+- No Effect when there is no external system to synchronize with. Effect cleanup must fully mirror setup.
+- Do not mirror props or derived values into state; derive during render.
+- `useMemo` only for measurably expensive work or to stabilize values that materially affect memoization/Effect behavior. `memo` is a performance optimization only, never correctness. Prefer default shallow comparison; add custom comparators only with profiling evidence and tests proving they hide no updates.
+- Prefer `ref` as a prop; use `forwardRef` only when unavoidable.
+- For external data subscriptions prefer `useSyncExternalStore`, kept SSR-safe.
+- Code must be correct under Strict Mode and concurrent rendering.
 
-## Components, Hooks, and Utilities
+## Components, Hooks, Utilities
 
-- Prefer function components. Use class components only where React still requires them, such as error boundaries.
-- Keep components focused. Extract pure helper functions for reusable data shaping, geometry work, validation, or formatting logic.
-- Create custom hooks only when they encapsulate real reusable stateful or Effectful behavior. Do not create hooks as indirection for one-off logic.
-- Memoize expensive geography path, projection, or coordinate calculations where it materially reduces render cost.
-- Never render HTML elements inside SVG subtrees where SVG elements are required. Loading and error fallbacks inside `<svg>` / `<g>` trees must remain SVG-safe.
-- Keep debug behavior opt-in and safe. Do not add noisy logs, render-phase debug mutations, or production-only surprises.
+- Function components; classes only where React requires them (error boundaries).
+- Extract pure helpers for reusable geometry, validation, or formatting. Create custom hooks only for genuinely reusable stateful/Effectful behavior, not as indirection for one-off logic.
+- Memoize expensive geography path, projection, and coordinate calculations where it materially reduces render cost.
+- Never render HTML elements inside SVG subtrees. Loading and error fallbacks inside `<svg>`/`<g>` must stay SVG-safe.
+- Keep debug behavior opt-in. No noisy logs or render-phase debug mutations.
 
-## TypeScript and Public API Design
+## TypeScript and Public API
 
-- Avoid `any`; use `unknown`, proper generics, or explicit types plus type guards.
-- Use branded coordinate helpers for new APIs (`createCoordinates`, `createScaleExtent`, `createTranslateExtent`) and keep those helpers consistent across the codebase.
-- Keep exported types intentional and stable. Do not leak internal-only implementation details through the public API without a clear reason.
-- Favor small, composable props and utilities over large configuration objects when that keeps the API clearer.
-- Validate untrusted inputs at package boundaries and surface precise, actionable errors.
-
-Example (branded coordinates):
-
-```tsx
-import { createCoordinates } from '@vnedyalk0v/react19-simple-maps';
-
-const center = createCoordinates(0, 0);
-```
+- Avoid `any`; use `unknown`, generics, or explicit types with type guards.
+- Use the branded coordinate helpers for new APIs (`createCoordinates`, `createScaleExtent`, `createTranslateExtent`) and keep them consistent across the codebase.
+- Keep exported types intentional and stable; do not leak internals without reason.
+- Favor small composable props over large config objects. Validate untrusted input at package boundaries with precise, actionable errors.
 
 ## Security and Geography Fetching
 
-- For URL-based geography data, use existing secure utilities (`fetchGeographiesCache`, validation helpers, SRI helpers).
-- Preserve HTTPS-only defaults, private IP blocking, redirect validation, response-size limits, and content validation.
-- Do not weaken security defaults without an explicit user request and matching tests/docs.
-- Update known SRI hashes only when adding verified URLs.
-- Keep any preloading, DNS hinting, or caching logic aligned with the same validation rules as the main fetch path.
-- Security hardening must preserve documented supported runtimes. If a safeguard depends on a platform API, provide a compatible fallback for supported Node versions.
-- Partial security configuration updates must be composable unless replacement behavior is explicitly documented.
-- When changing SRI sources or hashes, also verify that the generator inputs and checked-in generated artifacts stay in sync.
+`src/utils/` holds security-sensitive fetch, validation, cache, preload, and SRI logic.
 
-## Performance, KISS, and DRY
+- Use the existing secure utilities (`fetchGeographiesCache`, validation helpers, SRI helpers) for URL-based geography data.
+- Preserve HTTPS-only defaults, private-IP blocking, redirect validation, response-size limits, and content validation. Do not weaken defaults without an explicit request plus tests and docs.
+- Keep preloading, DNS hinting, and caching aligned with the main fetch path's validation rules.
+- Update known SRI hashes only for verified URLs; rerun the generator and confirm checked-in artifacts match.
+- Security hardening must preserve documented supported runtimes — provide a fallback when a safeguard depends on a newer platform API.
+- Partial security config updates must compose unless replacement behavior is documented.
 
-- Prefer the simplest solution that preserves package quality.
-- Avoid overengineering: no unnecessary managers, registries, service layers, wrapper hooks, or configuration systems.
-- Keep duplication low, but do not extract abstractions too early. Extract only when reuse or clarity is real.
-- Optimize hot paths and exported components, not hypothetical bottlenecks.
-- Minimize prop churn, object recreation, and unnecessary Effect-driven re-renders in performance-sensitive components.
-- Be conservative with new features that add maintenance cost, API surface, or bundle weight.
+## Tests
+
+- Add or update tests for behavior changes; add a focused regression test for bug fixes when practical.
+- Keep tests deterministic — no unnecessary network or timing fragility.
+- Prefer behavioral assertions over implementation details, especially under Strict Mode.
+- Verify review findings against current code before changing anything.
 
 ## Docs and Examples
 
-- Documentation must match the current implementation.
-- Remove unverifiable claims; prefer concrete statements tied to the repo.
-- Examples should demonstrate idiomatic package usage, not app-specific workarounds.
-- If you change public APIs, update examples and README accordingly.
-- If docs or examples show sequential configuration calls, verify that the documented call order composes correctly in the implementation.
-
-## Tests and Validation
-
-- Add or update tests for behavior changes.
-- For bug fixes, add a focused regression test when practical.
-- Keep tests focused, deterministic, and free of unnecessary network or timing fragility.
-- When touching exported behavior, security-sensitive code, or build/package configuration, run the most relevant validation commands before finishing.
-- Verify review findings against the current code before fixing them. Only change code for findings that are actually valid.
-- Prefer behavioral assertions over implementation-detail assertions, especially under Strict Mode.
-- For fixes involving generated files, rerun the generator and verify the output matches the checked-in artifacts.
-- Before reporting completion, verify the relevant local commands, PR checks, and branch or merge state directly.
+- Documentation must match the current implementation; drop unverifiable claims.
+- Examples demonstrate idiomatic package usage, not app-specific workarounds.
+- If docs show sequential configuration calls, verify the documented order actually composes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Prefer KISS and DRY. No app-like abstractions, no speculative architecture, no b
 - `npm run lint:fix`, `npm run format` — autofix
 - `npm run analyze` — bundle size report
 - `npm run generate-sri` — regenerate `scripts/sri-hashes.json` and `src/utils/generated-sri-hashes.ts`
-- Examples: `cd examples/<name> && npm ci --ignore-scripts && npm run build`
+- Examples: `npm run build` at the root first (they link to it via `file:../..` and resolve through `dist/`), then `cd examples/<name> && npm ci --ignore-scripts && npm run build`
 
 ## Git Workflow (Required)
 
@@ -29,7 +29,9 @@ Prefer KISS and DRY. No app-like abstractions, no speculative architecture, no b
 - Conventional Commits (`fix(build): ...`, `chore(deps): ...`).
 - Before claiming a fix is in `dev` or in a PR, verify actual git/GitHub state rather than relying on memory.
 
-## Before Pushing (Required)
+## Before Committing (Required)
+
+Run this gate while the work is still uncommitted — `--type uncommitted` inspects the working tree, so running it after a commit reviews nothing.
 
 1. Run `npm run ci`. Add targeted checks when the touched area needs them: example builds, `npm run analyze`, `npm pack --dry-run`, generator reruns.
 2. Run CodeRabbit CLI as the final local review and wait for it to finish:
@@ -41,7 +43,7 @@ Prefer KISS and DRY. No app-like abstractions, no speculative architecture, no b
    (`coderabbit review --agent --type uncommitted --base dev` if the `cr` alias is unavailable.)
 
 3. Treat findings as input, not truth. Verify each against current code, fix valid ones, rerun.
-4. Push only after validation passes and no valid recommendations remain. If CodeRabbit cannot run (auth, install, connectivity), run `cr doctor`, report the blocker, and do not push unless the user explicitly approves bypassing this gate.
+4. Commit and push only after validation passes and no valid recommendations remain. If CodeRabbit cannot run (auth, install, connectivity, rate limit), run `cr doctor`, report the blocker, and do not push unless the user explicitly approves bypassing this gate.
 
 ## Pull Request Review Gate (Required)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pnpm add @vnedyalk0v/react19-simple-maps
 
 - **React**: 19.0.0 or higher (peer dependency)
 - **React DOM**: 19.0.0 or higher (peer dependency)
-- **Node.js**: 20.19.0 or higher (development/build)
+- **Node.js**: 24.15.0 or higher for development and builds — CI validates on the current Node 24 release
 - **TypeScript**: 5.0.0 or higher (recommended)
 
 For support expectations, compatibility boundaries, and release behavior, see the [Support Policy](./docs/support.md).
@@ -277,11 +277,15 @@ REACT_SIMPLE_MAPS_DEBUG=true
 ```bash
 npm install
 npm run dev
-npm run build
-npm run test
-npm run type-check
-npm run lint
 ```
+
+`npm run ci` is the full validation gate and runs build, type-check, lint, format check, tests, and build verification:
+
+```bash
+npm run ci
+```
+
+Individual steps are also available: `npm run build`, `npm run test`, `npm run type-check`, `npm run lint`.
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pnpm add @vnedyalk0v/react19-simple-maps
 
 - **React**: 19.0.0 or higher (peer dependency)
 - **React DOM**: 19.0.0 or higher (peer dependency)
-- **Node.js**: 24.15.0 or higher for development and builds — CI validates on the current Node 24 release
+- **Node.js**: 24.15.0 or higher on the Node 24 line for development and builds — the line CI validates. Node 25 is excluded by the locked test toolchain; see the [Support Policy](./docs/support.md).
 - **TypeScript**: 5.0.0 or higher (recommended)
 
 For support expectations, compatibility boundaries, and release behavior, see the [Support Policy](./docs/support.md).

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -26,18 +26,15 @@ Runs on:
 - PRs to `main`
 - pushes to `dev`
 
-The workflow installs dependencies with lifecycle scripts disabled and uses the
-canonical validation command:
+The workflow installs dependencies with lifecycle scripts disabled
+(`npm ci --ignore-scripts`) and defines three jobs:
 
-```bash
-npm ci --ignore-scripts
-```
+- `validate` — runs `npm run ci` under a Node.js matrix (currently `24`)
+- `example-builds` — builds the root package, then installs and builds both
+  examples with lifecycle scripts disabled to verify they work with the package
+- `ci` — the required status check, which fails unless both jobs above succeed
 
-```bash
-npm run ci
-```
-
-`npm run ci` runs the local validation steps:
+`npm run ci` is the canonical validation contract and runs:
 
 - build
 - type-check
@@ -45,15 +42,6 @@ npm run ci
 - formatting check
 - tests
 - build verification
-- runs validation under a Node.js matrix (20, 22) in the `validate` job
-- builds examples in a separate `example-builds` job to verify they work with the package
-
-The CI orchestration itself lives in `.github/workflows/ci.yml`, which defines:
-
-- the `validate` job, running `npm run ci` under a Node.js matrix (`20`, `22`)
-- the `example-builds` job, which builds the root package explicitly, installs
-  each example with lifecycle scripts disabled, and builds both examples
-  separately to verify they work with the package
 
 This keeps dependency installation free of package builds while making
 `npm run ci` the explicit package validation and build contract.

--- a/docs/support.md
+++ b/docs/support.md
@@ -8,7 +8,7 @@
 
 ## Development and build support
 
-- Local development, tests, and package builds require **Node.js 24.15.0 or newer**. CI runs the current Node 24 release. Engine ranges declared by the development toolchain rule out Node 20, earlier 22.x releases, and Node 24.0 through 24.14.
+- Local development, tests, and package builds require **Node.js 24.15.0 or newer on the Node 24 line**, which is what CI runs. Engine ranges declared by the development toolchain rule out Node 20, earlier 22.x releases, Node 24.0 through 24.14, and all of Node 25.
 
 ## API and release expectations
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -8,8 +8,7 @@
 
 ## Development and build support
 
-- Local development, tests, and package builds require **Node.js 20.19.0 or newer**.
-- CI validates the repository on **Node.js 20** and **Node.js 22**.
+- Local development, tests, and package builds require **Node.js 24.15.0 or newer**. CI runs the current Node 24 release. Engine ranges declared by the development toolchain rule out Node 20, earlier 22.x releases, and Node 24.0 through 24.14.
 
 ## API and release expectations
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,9 +25,9 @@ npm run dev
 
 ## Requirements
 
-- Node.js 18+
-- TypeScript 5.0+
+- Node.js 24.15.0 or newer, matching the repository requirement. CI builds the examples on the current Node 24 release, in the same job that installs the root package.
 - React 19+
+- The examples pin TypeScript 6 and Vite 8 in their own `package.json`
 
 ## TypeScript Configuration
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,9 +15,11 @@ See [SECURITY.md](./SECURITY.md) for details.
 
 ## Running Examples
 
-Each example is a standalone TypeScript project. To run one:
+Each example is a standalone TypeScript project that links to the root package with `file:../..`, so build the root package first:
 
 ```bash
+npm install && npm run build   # from the repository root
+
 cd examples/basic-map
 npm install
 npm run dev
@@ -25,7 +27,7 @@ npm run dev
 
 ## Requirements
 
-- Node.js 24.15.0 or newer, matching the repository requirement. CI builds the examples on the current Node 24 release, in the same job that installs the root package.
+- Node.js 24.15.0 or newer on the Node 24 line, matching the repository requirement. CI builds the examples in the same job that installs and builds the root package.
 - React 19+
 - The examples pin TypeScript 6 and Vite 8 in their own `package.json`
 

--- a/examples/SECURITY.md
+++ b/examples/SECURITY.md
@@ -8,8 +8,7 @@ Both examples include CSP meta tags in `index.html`, and the Vite dev server set
 
 - **HTML meta tags** allow `self` plus `https://unpkg.com` for geography data.
 - **Dev server headers** add `ws:`/`wss:` for Vite HMR and also set `frame-ancestors 'none'`.
-- The **interactive example** includes `frame-ancestors 'none'` in its meta tag.
-- The **basic example** does not include `frame-ancestors` in the meta tag (see the comment in `index.html`).
+- Neither example sets `frame-ancestors` in its meta tag, because browsers ignore that directive in meta-delivered CSP. It must be delivered as an HTTP response header (see the comments in each `index.html`).
 
 ### CSP Directives Used (Development)
 
@@ -34,13 +33,16 @@ The directives above are **development defaults only**. Derive your production C
 
 ## Additional Security Headers
 
-The examples also set these headers (via HTML meta tags and dev server headers):
+The Vite dev server (`vite.config.ts`) sets these HTTP response headers in both examples:
 
 - `X-Content-Type-Options: nosniff`
 - `X-Frame-Options: DENY`
 - `X-XSS-Protection: 0` — Disables the legacy XSS auditor. The deprecated `1; mode=block` value can introduce cross-site leak vulnerabilities in older browsers. Rely on a strong Content Security Policy instead.
 - `Referrer-Policy: strict-origin-when-cross-origin`
-- `Permissions-Policy` (disabled features list)
+
+The `index.html` files repeat `X-Content-Type-Options`, `X-XSS-Protection`, and `Referrer-Policy` as `<meta http-equiv>` tags. Treat those as local-development documentation only. Security headers are dependable only when delivered as HTTP response headers, so set all of them at the server, CDN, or edge layer in production.
+
+`Permissions-Policy` is not set by the examples. It is an HTTP response header, so configure it at that same layer if you need it.
 
 ## Development vs Production
 

--- a/examples/basic-map/index.html
+++ b/examples/basic-map/index.html
@@ -31,11 +31,10 @@
 
     <!--
       DEVELOPMENT-ONLY fallbacks via meta tags.
-      Per HTML, Referrer-Policy is reliably enforceable from <meta http-equiv>.
-      X-Content-Type-Options and X-Frame-Options are not reliably honored via
-      http-equiv; deliver them (and the rest of your security headers) as HTTP
-      response headers in production (server / CDN / edge). Keep these meta tags
-      only as local-dev fallbacks.
+      X-Content-Type-Options, X-XSS-Protection, and X-Frame-Options are not
+      reliably honored via http-equiv; deliver them (and the rest of your
+      security headers) as HTTP response headers in production
+      (server / CDN / edge). Keep these meta tags only as local-dev fallbacks.
       See examples/SECURITY.md for details.
     -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />

--- a/examples/interactive-map/index.html
+++ b/examples/interactive-map/index.html
@@ -34,10 +34,11 @@
     />
 
     <!--
-      The headers below are DEVELOPMENT-ONLY fallbacks delivered via meta tags.
-      Browsers enforce X-Content-Type-Options and Referrer-Policy from meta tags,
-      but X-Frame-Options is only reliable as an HTTP header. For production,
-      set ALL security headers at the HTTP response layer (server / CDN / edge).
+      DEVELOPMENT-ONLY fallbacks via meta tags.
+      X-Content-Type-Options, X-XSS-Protection, and X-Frame-Options are not
+      reliably honored via http-equiv; deliver them (and the rest of your
+      security headers) as HTTP response headers in production
+      (server / CDN / edge). Keep these meta tags only as local-dev fallbacks.
       See examples/SECURITY.md for details.
     -->
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />


### PR DESCRIPTION
## Summary

Rewrites `AGENTS.md` as the guidance file for AI coding agents, adds `CLAUDE.md` (`@AGENTS.md`), and corrects documentation that disagreed with the repository.

## AGENTS.md

- New **Pull Request Review Gate** section: wait for the automated PR reviews, verify each finding against the code, fix valid ones, reply and resolve threads, request a re-review, and only merge once a round comes back clean with required checks green.
- New **Layout** and **Commands** sections (`npm run ci`, `analyze`, `generate-sri`, example builds).
- Branch model made explicit: `dev` integration, `main` release, required checks `ci` and `dependency-review`.
- Removed duplicated guidance (the mindset and performance sections restated the intro; three separate "verify before claiming done" rules collapsed into one).

## Documentation corrections

| File | Was | Now |
| --- | --- | --- |
| `docs/ci-cd.md` | Node matrix `(20, 22)`, stated twice, with the matrix and example-build bullets listed as steps of `npm run ci` | Matrix `24` matching `ci.yml`; jobs and `npm run ci` steps separated |
| `docs/support.md` | "CI validates on Node.js 20 and Node.js 22" | Node 24.15.0+ on the Node 24 line, with the excluded ranges named |
| `README.md` | "Node.js 20.19.0 or higher" | Same requirement; `npm run ci` documented as the validation gate |
| `examples/README.md` | "Node.js 18+"; run recipe omitted the root build | Matching Node requirement; both recipes build the root package first |
| `examples/SECURITY.md` | Claimed the interactive example sets `frame-ancestors` in its meta tag; listed `X-Frame-Options` as meta-delivered; listed a `Permissions-Policy` that is not set anywhere | Corrected against `index.html` and `vite.config.ts` |
| `examples/*/index.html` | The two files' security-header comments contradicted each other | Aligned, and an unverifiable claim about meta-delivered `Referrer-Policy` removed |

The documented Node floor is `24.15.0` on the Node 24 line because the locked test toolchain declares `^22.22.2 || ^24.15.0 || >=26.0.0`, which excludes Node 20, earlier 22.x, 24.0-24.14, and all of Node 25.

The example build recipes now build the root package first: the examples link with `file:../..` and resolve through the `exports` map to `dist/`, which is gitignored, so a clean checkout cannot build them otherwise.

## Validation

- `npm run ci` passes.
- The local pre-commit review gate returned no findings on the final change.

No changeset: documentation-only, no package behavior change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates repository documentation and agent guidance. The main changes are:

- Rewrites `AGENTS.md` with workflow, validation, PR review, package, React, security, and docs guidance.
- Adds `CLAUDE.md` as a pointer to `AGENTS.md`.
- Aligns README, support, and CI docs with the current Node 24 CI setup and `npm run ci` gate.
- Updates example setup instructions to build the root package before building examples.
- Corrects example security-header documentation and HTML comments to match the Vite dev-server headers and browser behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Documentation and comment-only changes; the revised claims match the workflow, manifests, lockfile engine constraint, and example Vite headers.

**Files Needing Attention:** No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the CI workflow by executing npm run ci in /home/user/repo; the run started at 2026-07-31T06:33:02+00:00 and ended at 2026-07-31T06:33:19+00:00 after 17 seconds, and the log shows a failing subcommand npm run check-format (prettier --check .) with exit code 1.

<a href="https://app.greptile.com/trex/runs/16725153/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Rewrites agent guidance with updated workflow, validation, PR review, package, React, security, and docs expectations; no issues found. |
| CLAUDE.md | Adds a Claude guidance pointer to `AGENTS.md`; no issues found. |
| README.md | Updates development Node support language and documents `npm run ci` as the validation gate; no issues found. |
| docs/ci-cd.md | Corrects CI documentation to match the current Node 24 matrix and separates workflow jobs from local `npm run ci` steps; no issues found. |
| docs/support.md | Aligns support policy with the current locked toolchain's Node requirements; no issues found. |
| examples/README.md | Updates example setup instructions to build the root package first and align dependency requirements; no issues found. |
| examples/SECURITY.md | Corrects example security-header documentation to distinguish meta-delivered CSP from HTTP headers; no issues found. |
| examples/basic-map/index.html | Aligns development-only security-header comments with documented browser/header behavior; no issues found. |
| examples/interactive-map/index.html | Aligns development-only security-header comments with the basic example and security docs; no issues found. |

<sub>Reviews (4): Last reviewed commit: ["docs: fix example build recipe, Node 25 ..."](https://github.com/vnedyalk0v/react19-simple-maps/commit/b903f00b896e7196fb22e05ab9df68623c5e57f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48688866)</sub>

<!-- /greptile_comment -->